### PR TITLE
Remove the 'system' suffix from the capi-provider-agent default namespace

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: cluster-api-provider-agent-system
+namespace: cluster-api-provider-agent
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,17 +1,14 @@
 # Adds namespace to all resources.
 namespace: cluster-api-provider-agent
-
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
 namePrefix: cluster-api-provider-agent-
-
 # Labels to add to all resources and selectors.
 #commonLabels:
 #  someName: someValue
-
 bases:
 - ../crd
 - ../rbac
@@ -29,7 +26,6 @@ patchesStrategicMerge:
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
-
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
 #- manager_config_patch.yaml


### PR DESCRIPTION
Allow specifying the namespace when deploying from source code