### PR TITLE
Mgmt 8764: agent fail to pull ignition in case the token is expired

### DIFF
--- a/controllers/agentmachine_controller.go
+++ b/controllers/agentmachine_controller.go
@@ -118,15 +118,15 @@ func (r *AgentMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, nil
 	}
 
-	if machine.Spec.Bootstrap.DataSecretName != nil && agent.Spec.MachineConfigPool == "" {
-		return r.setAgentIgnitionEndpoint(ctx, log, agent, agentMachine, machine)
-	}
-
 	// If the AgentMachine has an Agent but the Agent doesn't reference the ClusterDeployment,
 	// then set it. At this point we might find that the Agent is already bound and we'll need
 	// to find a new one.
 	if agent.Spec.ClusterDeploymentName == nil {
 		return r.setAgentClusterDeploymentRef(ctx, log, agentMachine, agent)
+	}
+
+	if machine.Spec.Bootstrap.DataSecretName != nil && agent.Spec.MachineConfigPool == "" {
+		return r.setAgentIgnitionEndpoint(ctx, log, agent, agentMachine, machine)
 	}
 
 	// If the AgentMachine has an agent, check its conditions and update ready/error


### PR DESCRIPTION
The HyperShift ignition token gets rotated every 60 minutes. 
This change updates the provider to set the machineConfigPool and ignition token on the agent only after the agent is bound to a ClusterDeployment.
This should minimize the problem but the race still exists