### PR TITLE
Mgmt 8764: agent fail to pull ignition due to expired token

### DIFF
--- a/controllers/agentmachine_controller.go
+++ b/controllers/agentmachine_controller.go
@@ -272,7 +272,7 @@ func (r *AgentMachineReconciler) setAgentIgnitionEndpoint(ctx context.Context, l
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	log.Infof("Setting MachineConfigPool to %s", agent.Spec.MachineConfigPool)
+	log.Infof("Setting MachineConfigPool to %s", ignitionSourceSuffix)
 	agent.Spec.MachineConfigPool = ignitionSourceSuffix
 
 	token := ""


### PR DESCRIPTION
All agents belonging to the same node pool use the same ignitionTokenSecret.
The provider assumed the token never changes but it seems that HyperShift updates the token inside the userDataSecret, hence the provider should update the ignitionTokenSecret as well.