### PR TITLE
MGMT-8819:  List agents by namespace

### DIFF
--- a/controllers/agentmachine_controller_test.go
+++ b/controllers/agentmachine_controller_test.go
@@ -146,9 +146,10 @@ var _ = Describe("agentmachine reconcile", func() {
 		mockCtrl = gomock.NewController(GinkgoT())
 
 		amr = &AgentMachineReconciler{
-			Client: c,
-			Scheme: scheme.Scheme,
-			Log:    logrus.New(),
+			Client:      c,
+			Scheme:      scheme.Scheme,
+			Log:         logrus.New(),
+			AgentClient: c,
 		}
 	})
 


### PR DESCRIPTION
Add a additional controller manager to handle cache of Agents on a different namespace than the CAPI objects.