### PR TITLE
BZ2047937: Fix Make deploy manager arguments

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -25,5 +25,5 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
-        - "--namespace ${WATCH_NAMESPACE}"
-        - "--agent-namespace ${AGENTS_NAMESPACE}"
+        - "--namespace=${WATCH_NAMESPACE}"
+        - "--agent-namespace=${AGENTS_NAMESPACE}"


### PR DESCRIPTION
BZ2047937: Stops manager from crashing when using `make deploy` with `WATCH_NAMESPACE capi-0 AGENTS_NAMESPACE=capi-0-workers` arguments.