### PR TITLE
Update Makefile to allow setting runtime CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.21
 
+# Runtime CLI to use for building and pushing images
+RUNTIME ?= docker
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -110,10 +113,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	${RUNTIME} build -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	${RUNTIME} push ${IMG}
 
 ##@ Deployment
 
@@ -185,7 +188,7 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	${RUNTIME} build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.


### PR DESCRIPTION
This commit adds RUNTIME variable to Makefile so that developer can
configure a desired CLI for building and pushing images. The default
value is `docker` so that the behaviour is not modified but allows to
easily plug podman.

/cc @avishayt 