### PR TITLE
MGMT-9390: Add owner ref on the ClusterDeployment

### DIFF
--- a/controllers/agentcluster_controller.go
+++ b/controllers/agentcluster_controller.go
@@ -89,7 +89,7 @@ func (r *AgentClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	result, err := r.ensureAgentClusterInstall(ctx, log, clusterDeployment)
-	if err != nil || result.Requeue{
+	if err != nil || result.Requeue {
 		return result, err
 	}
 
@@ -210,6 +210,12 @@ func (r *AgentClusterReconciler) createClusterDeploymentObject(agentCluster *cap
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      agentCluster.Name,
 			Namespace: agentCluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				Kind:       agentCluster.Kind,
+				APIVersion: agentCluster.APIVersion,
+				Name:       agentCluster.Name,
+				UID:        agentCluster.UID,
+			}},
 		},
 		Spec: hivev1.ClusterDeploymentSpec{
 			Installed:   true,

--- a/controllers/agentcluster_controller_test.go
+++ b/controllers/agentcluster_controller_test.go
@@ -212,6 +212,10 @@ var _ = Describe("agentcluster reconcile", func() {
 		Expect(clusterDeployment.Spec.ClusterMetadata.AdminKubeconfigSecretRef.Name).To(Equal(kubeconfig))
 		Expect(clusterDeployment.Spec.ClusterMetadata.ClusterID).To(Equal(string(agentCluster.OwnerReferences[0].UID)))
 		Expect(clusterDeployment.Spec.ClusterMetadata.InfraID).To(Equal(string(agentCluster.OwnerReferences[0].UID)))
+		Expect(clusterDeployment.OwnerReferences[0].UID).To(Equal(agentCluster.UID))
+		Expect(clusterDeployment.OwnerReferences[0].Name).To(Equal(agentCluster.Name))
+		Expect(clusterDeployment.OwnerReferences[0].Kind).To(Equal(agentCluster.Kind))
+		Expect(clusterDeployment.OwnerReferences[0].APIVersion).To(Equal(agentCluster.APIVersion))
 
 	})
 	It("failed to find cluster", func() {


### PR DESCRIPTION
Currently, when running with HIVE the cluster_controller fails to create the ClusterDeploymeent due to:
```
"error": "admission webhook \"ocm.validating.webhook.admission.open-cluster-management.io\" denied the request: user \"system:serviceaccount:clusters-hdhcp-0:capi-provider\" cannot add/remove the resource to/from ManagedClusterSet 
```
Adding the OwnerRef should enable ACM to skip this webhook (they do a similar trick for clusterclaim)