### PR TITLE
Cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ envtest: ## Download envtest-setup locally if necessary.
 
 MOCKGEN = $(shell pwd)/bin/mockgen
 mockgen: ## Download mockgen locally if necessary.
-	$(call go-get-tool,$(MOCKGEN),github.com/golang/mock/mockgen)
+	$(call go-get-tool,$(MOCKGEN),github.com/golang/mock/mockgen@latest)
 
 GOLINT = $(shell pwd)/bin/golangci-lint
 golint: ## Download golangci-lint locally if necessary.
@@ -172,12 +172,8 @@ PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f $(1) ] || { \
 set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
-rm -rf $$TMP_DIR ;\
+echo "Installing $(2)" ;\
+GOFLAGS="" GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 }
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ mockgen: ## Download mockgen locally if necessary.
 
 GOLINT = $(shell pwd)/bin/golangci-lint
 golint: ## Download golangci-lint locally if necessary.
-	@[ -f $(GOLINT) ] || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell pwd)/bin v1.43.0
+	$(call go-get-tool,$(GOLINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.

--- a/main.go
+++ b/main.go
@@ -29,8 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-
-	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"


### PR DESCRIPTION
* Fix lint issue See https://github.com/golangci/golangci-lint/issues/2601
* Install golangci-lint from source See https://github.com/golangci/golangci-lint/issues/2374
* Updated kustomize version to a version that support go install See https://github.com/kubernetes-sigs/kustomize/issues/3618
* go 1.17 has deprecated installing executables with `go get`
* Refactor - don't pass around origRes and origErr