### PR TITLE
Set user maneged networking to true in the agentCluster agentClusterInstall

### DIFF
--- a/controllers/agentcluster_controller.go
+++ b/controllers/agentcluster_controller.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-openapi/swag"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	capiproviderv1alpha1 "github.com/openshift/cluster-api-provider-agent/api/v1alpha1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -277,6 +278,7 @@ func (r *AgentClusterReconciler) createAgentClusterInstall(ctx context.Context, 
 			ProvisionRequirements: hiveext.ProvisionRequirements{
 				ControlPlaneAgents: 3,
 			},
+			Networking: hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
 		},
 	}
 

--- a/controllers/agentcluster_controller_test.go
+++ b/controllers/agentcluster_controller_test.go
@@ -273,6 +273,7 @@ var _ = Describe("agentcluster reconcile", func() {
 
 		agentClusterInstall := &hiveext.AgentClusterInstall{}
 		Expect(c.Get(ctx, key, agentClusterInstall)).To(BeNil())
+		Expect(*agentClusterInstall.Spec.Networking.UserManagedNetworking).To(BeTrue())
 	})
 	It("agentCluster missing controlPlaneEndpoint", func() {
 		agentCluster := newAgentCluster("agentCluster-1", testNamespace, capiproviderv1alpha1.AgentClusterSpec{


### PR DESCRIPTION
This should allow the assisted-service to approve the node (and kubelet) CSRs