### PR TITLE
MGMT-12840: set restricted list of approvers for 2.7

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,8 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
+- romfreiman
+- filanov
+- gamli75
 - eranco74
-- avishayt
 - osherdp
-- mkowalski


### PR DESCRIPTION
Since there are (currently) no label restrictions on attached Jira bugs, we don't have a good way to enforce people are only merging bug-fixes / security-patches.

Setting a smaller approvers list can help us enforce this kind of restriction (list might change later on, if needed)

/cc @filanov @gamli75 @romfreiman @eranco74 