### PR TITLE
Add back the agent machine finalizer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,8 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
+- romfreiman
+- filanov
+- gamli75
 - eranco74
-- avishayt
 - osherdp
-- mkowalski


### PR DESCRIPTION
In https://github.com/openshift/cluster-api-provider-agent/commit/e6fa01e907d7beac4f74d4395a63e768f993e468 the machine pre-delete hook replaced this finalizer, but it
now seems that there are scenarios where the `AgentMachine` could be
deleted before the `Machine`. Before this change this would mean that
the pre-delete hook would never get removed from the `Machine`, stalling
the delete process indefinitely.

Now this finalizer will prevent `AgentMachines` from being removed before
the pre-delete work is processed for the `Machine`. The annotation is
added and removed at the same time as the pre-delete hook.

Resolves https://issues.redhat.com/browse/ACM-2841
Backports https://github.com/openshift/cluster-api-provider-agent/pull/62 to 2.7