### PR TITLE
ACM-3757: Undo changes to agents upon unbinding

### DIFF
--- a/controllers/agentmachine_controller.go
+++ b/controllers/agentmachine_controller.go
@@ -243,6 +243,9 @@ func (r *AgentMachineReconciler) handleDeletionHook(ctx context.Context, log log
 	if funk.Contains(agent.ObjectMeta.Labels, AgentMachineRefLabelKey) || agent.Spec.ClusterDeploymentName != nil {
 		r.Log.Info("Removing ClusterDeployment ref to unbind Agent")
 		delete(agent.ObjectMeta.Labels, AgentMachineRefLabelKey)
+		delete(agent.ObjectMeta.Annotations, AgentMachineRefNamespace)
+		agent.Spec.MachineConfigPool = ""
+		agent.Spec.IgnitionEndpointTokenReference = nil
 		agent.Spec.ClusterDeploymentName = nil
 		if err := r.Update(ctx, agent); err != nil {
 			log.WithError(err).Error("failed to remove the Agent's ClusterDeployment ref")


### PR DESCRIPTION
We modify an agent when associating it with an agentMachine, but failed to undo those changes upon disassociating it. This commit fixes that.