### PR TITLE
MGMT-15235: Compile with CGO_ENABLED=1 for FIPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.17 as builder
 WORKDIR /workspace
 COPY . .
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 FROM registry.ci.openshift.org/ocp/4.10:base
 WORKDIR /


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-15235
In order to be FIPS compliant, we need to compile
all go code with CGO_ENABLED=1.

/cc @eranco74 @filanov 