### PR TITLE
[release-ocm-2.9] MGMT-14838: Update vendor directory after backporting v1beta1 changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/openshift/api v0.0.0-20230915112357-693d4b64813c // indirect
+	github.com/openshift/api v0.0.0-20231020115248-f404f2bc3524 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
 github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
-github.com/openshift/api v0.0.0-20230915112357-693d4b64813c h1:ro/BvvpAikMoZc/fsxJN6jxmK+4uIbdNIK9nwaFQ5xo=
-github.com/openshift/api v0.0.0-20230915112357-693d4b64813c/go.mod h1:NFgA+laiQtptmjsp1trDnGqjV62nYzlUfQ6P5I9oqXA=
+github.com/openshift/api v0.0.0-20231020115248-f404f2bc3524 h1:+hOy0dbg/WIQ2TpBh+aWmoKTHYB82nSM8CfIZtjBmr8=
+github.com/openshift/api v0.0.0-20231020115248-f404f2bc3524/go.mod h1:qNtV0315F+f8ld52TLtPvrfivZpdimOzTi3kn9IVbtU=
 github.com/openshift/assisted-service/api v0.0.0-20220811161334-09c4cb098e96 h1:/hFV74JO0/fLqhTFjcmL0UNCfeZX9EMf2JRLdWeT8Wo=
 github.com/openshift/assisted-service/api v0.0.0-20220811161334-09c4cb098e96/go.mod h1:KXLo37GRdMYq/8PHRbvWPW9AEZjLI3NdFCySAwBJfAQ=
 github.com/openshift/assisted-service/models v0.0.0-20220811161334-09c4cb098e96 h1:PuiMFgQfq3IpJg2nJHtAtRwXrRsMhXotXPcdFgdZaH0=

--- a/vendor/github.com/openshift/api/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -75,6 +75,7 @@ spec:
                           - Build
                           - DeploymentConfig
                           - ImageRegistry
+                          - OperatorLifecycleManager
                       x-kubernetes-list-type: atomic
                     baselineCapabilitySet:
                       description: baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.
@@ -85,6 +86,7 @@ spec:
                         - v4.12
                         - v4.13
                         - v4.14
+                        - v4.15
                         - vCurrent
                 channel:
                   description: channel is an identifier for explicitly requesting that a non-default set of updates be applied to this cluster. The default channel will be contain stable updates that are appropriate for production clusters.
@@ -201,6 +203,7 @@ spec:
                           - Build
                           - DeploymentConfig
                           - ImageRegistry
+                          - OperatorLifecycleManager
                       x-kubernetes-list-type: atomic
                     knownCapabilities:
                       description: knownCapabilities lists all the capabilities known to the current cluster.
@@ -221,6 +224,7 @@ spec:
                           - Build
                           - DeploymentConfig
                           - ImageRegistry
+                          - OperatorLifecycleManager
                       x-kubernetes-list-type: atomic
                 conditionalUpdates:
                   description: conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.
@@ -445,6 +449,8 @@ spec:
           x-kubernetes-validations:
             - rule: 'has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities) && self.spec.capabilities.baselineCapabilitySet == ''None'' && ''baremetal'' in self.spec.capabilities.additionalEnabledCapabilities ? ''MachineAPI'' in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status) && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities) && ''MachineAPI'' in self.status.capabilities.enabledCapabilities) : true'
               message: the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability
+            - rule: 'has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities) && self.spec.capabilities.baselineCapabilitySet == ''None'' && ''marketplace'' in self.spec.capabilities.additionalEnabledCapabilities ? ''OperatorLifecycleManager'' in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status) && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities) && ''OperatorLifecycleManager'' in self.status.capabilities.enabledCapabilities) : true'
+              message: the `marketplace` capability requires the `OperatorLifecycleManager` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `OperatorLifecycleManager` capability
       served: true
       storage: true
       subresources:

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_image.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_image.crd.yaml
@@ -100,7 +100,7 @@ spec:
                   items:
                     type: string
                 internalRegistryHostname:
-                  description: internalRegistryHostname sets the hostname for the default internal image registry. The value must be in "hostname[:port]" format. This value is set by the image registry operator which controls the internal registry hostname. For backward compatibility, users can still use OPENSHIFT_DEFAULT_REGISTRY environment variable but this setting overrides the environment variable.
+                  description: internalRegistryHostname sets the hostname for the default internal image registry. The value must be in "hostname[:port]" format. This value is set by the image registry operator which controls the internal registry hostname.
                   type: string
       served: true
       storage: true

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure-CustomNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure-CustomNoUpgrade.crd.yaml
@@ -655,7 +655,7 @@ spec:
                                 description: key is the key part of the label. A label key can have a maximum of 63 characters and cannot be empty. Label key must begin with a lowercase letter, and must contain only lowercase letters, numeric characters, and the following special characters `_-`. Label key must not have the reserved prefixes `kubernetes-io` and `openshift-io`.
                                 maxLength: 63
                                 minLength: 1
-                                pattern: ^[a-z][0-9a-z_-]+$
+                                pattern: ^[a-z][0-9a-z_-]{0,62}$
                                 type: string
                                 x-kubernetes-validations:
                                   - message: label keys must not start with either `openshift-io` or `kubernetes-io`
@@ -664,7 +664,7 @@ spec:
                                 description: value is the value part of the label. A label value can have a maximum of 63 characters and cannot be empty. Value must contain only lowercase letters, numeric characters, and the following special characters `_-`.
                                 maxLength: 63
                                 minLength: 1
-                                pattern: ^[0-9a-z_-]+$
+                                pattern: ^[0-9a-z_-]{1,63}$
                                 type: string
                             required:
                               - key

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
@@ -655,7 +655,7 @@ spec:
                                 description: key is the key part of the label. A label key can have a maximum of 63 characters and cannot be empty. Label key must begin with a lowercase letter, and must contain only lowercase letters, numeric characters, and the following special characters `_-`. Label key must not have the reserved prefixes `kubernetes-io` and `openshift-io`.
                                 maxLength: 63
                                 minLength: 1
-                                pattern: ^[a-z][0-9a-z_-]+$
+                                pattern: ^[a-z][0-9a-z_-]{0,62}$
                                 type: string
                                 x-kubernetes-validations:
                                   - message: label keys must not start with either `openshift-io` or `kubernetes-io`
@@ -664,7 +664,7 @@ spec:
                                 description: value is the value part of the label. A label value can have a maximum of 63 characters and cannot be empty. Value must contain only lowercase letters, numeric characters, and the following special characters `_-`.
                                 maxLength: 63
                                 minLength: 1
-                                pattern: ^[0-9a-z_-]+$
+                                pattern: ^[0-9a-z_-]{1,63}$
                                 type: string
                             required:
                               - key

--- a/vendor/github.com/openshift/api/config/v1/0000_10_openshift-controller-manager-operator_01_build.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_openshift-controller-manager-operator_01_build.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    capability.openshift.io/name: Build
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/vendor/github.com/openshift/api/config/v1/feature_gates.go
+++ b/vendor/github.com/openshift/api/config/v1/feature_gates.go
@@ -163,16 +163,6 @@ var (
 		OwningProduct:       kubernetes,
 	}
 
-	FeatureGateAdmissionWebhookMatchConditions = FeatureGateName("AdmissionWebhookMatchConditions")
-	admissionWebhookMatchConditions            = FeatureGateDescription{
-		FeatureGateAttributes: FeatureGateAttributes{
-			Name: FeatureGateAdmissionWebhookMatchConditions,
-		},
-		OwningJiraComponent: "kube-apiserver",
-		ResponsiblePerson:   "benluddy",
-		OwningProduct:       kubernetes,
-	}
-
 	FeatureGateAzureWorkloadIdentity = FeatureGateName("AzureWorkloadIdentity")
 	azureWorkloadIdentity            = FeatureGateDescription{
 		FeatureGateAttributes: FeatureGateAttributes{
@@ -299,6 +289,16 @@ var (
 		},
 		OwningJiraComponent: "ecoproject",
 		ResponsiblePerson:   "msluiter",
+		OwningProduct:       ocpSpecific,
+	}
+
+	FeatureGateDNSNameResolver = FeatureGateName("DNSNameResolver")
+	dnsNameResolver            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateDNSNameResolver,
+		},
+		OwningJiraComponent: "dns",
+		ResponsiblePerson:   "miciah",
 		OwningProduct:       ocpSpecific,
 	}
 )

--- a/vendor/github.com/openshift/api/config/v1/stable.build.testsuite.yaml
+++ b/vendor/github.com/openshift/api/config/v1/stable.build.testsuite.yaml
@@ -1,6 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "[Stable] Build"
-crd: 0000_10_config-operator_01_build.crd.yaml
+crd: 0000_10_openshift-controller-manager-operator_01_build.crd.yaml
 tests:
   onCreate:
   - name: Should be able to create a minimal Build

--- a/vendor/github.com/openshift/api/config/v1/stable.clusterversion.testsuite.yaml
+++ b/vendor/github.com/openshift/api/config/v1/stable.clusterversion.testsuite.yaml
@@ -130,6 +130,38 @@ tests:
           additionalEnabledCapabilities:
           - baremetal
     expectedError: the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability
+  - name: Should be able to create a ClusterVersion with base capability None, and additional capabilities marketplace and OperatorLifecycleManager
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+          - OperatorLifecycleManager
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+          - OperatorLifecycleManager
+  - name: Should not be able to create a ClusterVersion with base capability None, and additional capabilities marketplace without OperatorLifecycleManager
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+    expectedError: the `marketplace` capability requires the `OperatorLifecycleManager` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `OperatorLifecycleManager` capability
   onUpdate:
   - name: Should not allow image to be set if architecture set
     initial: |
@@ -276,3 +308,111 @@ tests:
           additionalEnabledCapabilities:
           - baremetal
     expectedError: the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability
+  - name: Should be able to add the marketplace capability with a ClusterVersion with base capability None, and implicitly enabled OperatorLifecycleManager
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+      status:
+        desired:
+          version: foo
+          image: foo
+        observedGeneration: 1
+        versionHash: foo
+        availableUpdates:
+        - version: foo
+          image: foo
+        capabilities:
+          enabledCapabilities:
+          - OperatorLifecycleManager
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+      status:
+        desired:
+          version: foo
+          image: foo
+        observedGeneration: 1
+        versionHash: foo
+        availableUpdates:
+        - version: foo
+          image: foo
+        capabilities:
+          enabledCapabilities:
+          - OperatorLifecycleManager
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+      status:
+        desired:
+          version: foo
+          image: foo
+        observedGeneration: 1
+        versionHash: foo
+        availableUpdates:
+        - version: foo
+          image: foo
+        capabilities:
+          enabledCapabilities:
+          - OperatorLifecycleManager
+  - name: Should be able to add the marketplace capability with a ClusterVersion with base capability None, with the OperatorLifecycleManager capability
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+          - OperatorLifecycleManager
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+          - OperatorLifecycleManager
+  - name: Should not be able to add the marketplace capability with a ClusterVersion with base capability None, and without OperatorLifecycleManager
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+    expectedError: the `marketplace` capability requires the `OperatorLifecycleManager` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `OperatorLifecycleManager` capability

--- a/vendor/github.com/openshift/api/config/v1/types_cluster_version.go
+++ b/vendor/github.com/openshift/api/config/v1/types_cluster_version.go
@@ -14,6 +14,7 @@ import (
 // Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 // +openshift:compatibility-gen:level=1
 // +kubebuilder:validation:XValidation:rule="has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities) && self.spec.capabilities.baselineCapabilitySet == 'None' && 'baremetal' in self.spec.capabilities.additionalEnabledCapabilities ? 'MachineAPI' in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status) && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities) && 'MachineAPI' in self.status.capabilities.enabledCapabilities) : true",message="the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability"
+// +kubebuilder:validation:XValidation:rule="has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities) && self.spec.capabilities.baselineCapabilitySet == 'None' && 'marketplace' in self.spec.capabilities.additionalEnabledCapabilities ? 'OperatorLifecycleManager' in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status) && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities) && 'OperatorLifecycleManager' in self.status.capabilities.enabledCapabilities) : true",message="the `marketplace` capability requires the `OperatorLifecycleManager` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `OperatorLifecycleManager` capability"
 type ClusterVersion struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -248,7 +249,7 @@ const (
 )
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Build;DeploymentConfig;ImageRegistry
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Build;DeploymentConfig;ImageRegistry;OperatorLifecycleManager
 type ClusterVersionCapability string
 
 const (
@@ -267,6 +268,9 @@ const (
 	// ClusterVersionCapabilityMarketplace manages the Marketplace operator which
 	// supplies Operator Lifecycle Manager (OLM) users with default catalogs of
 	// "optional" operators.
+	//
+	// Note that Marketplace has a hard requirement on OLM. OLM can not be disabled
+	// while Marketplace is enabled.
 	ClusterVersionCapabilityMarketplace ClusterVersionCapability = "marketplace"
 
 	// ClusterVersionCapabilityConsole manages the Console operator which
@@ -331,9 +335,14 @@ const (
 	// The following resources are taken into account:
 	// - deploymentconfigs
 	ClusterVersionCapabilityDeploymentConfig ClusterVersionCapability = "DeploymentConfig"
+
 	// ClusterVersionCapabilityImageRegistry manages the image registry which
 	// allows to distribute Docker images
 	ClusterVersionCapabilityImageRegistry ClusterVersionCapability = "ImageRegistry"
+
+	// ClusterVersionCapabilityOperatorLifecycleManager manages the Operator Lifecycle Manager
+	// which itself manages the lifecycle of operators
+	ClusterVersionCapabilityOperatorLifecycleManager ClusterVersionCapability = "OperatorLifecycleManager"
 )
 
 // KnownClusterVersionCapabilities includes all known optional, core cluster components.
@@ -350,10 +359,11 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 	ClusterVersionCapabilityBuild,
 	ClusterVersionCapabilityDeploymentConfig,
 	ClusterVersionCapabilityImageRegistry,
+	ClusterVersionCapabilityOperatorLifecycleManager,
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
-// +kubebuilder:validation:Enum=None;v4.11;v4.12;v4.13;v4.14;vCurrent
+// +kubebuilder:validation:Enum=None;v4.11;v4.12;v4.13;v4.14;v4.15;vCurrent
 type ClusterVersionCapabilitySet string
 
 const (
@@ -384,6 +394,12 @@ const (
 	// OpenShift.  This list will remain the same no matter which
 	// version of OpenShift is installed.
 	ClusterVersionCapabilitySet4_14 ClusterVersionCapabilitySet = "v4.14"
+
+	// ClusterVersionCapabilitySet4_15 is the recommended set of
+	// optional capabilities to enable for the 4.15 version of
+	// OpenShift.  This list will remain the same no matter which
+	// version of OpenShift is installed.
+	ClusterVersionCapabilitySet4_15 ClusterVersionCapabilitySet = "v4.15"
 
 	// ClusterVersionCapabilitySetCurrent is the recommended set
 	// of optional capabilities to enable for the cluster's
@@ -435,6 +451,21 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityDeploymentConfig,
 		ClusterVersionCapabilityImageRegistry,
 	},
+	ClusterVersionCapabilitySet4_15: {
+		ClusterVersionCapabilityBaremetal,
+		ClusterVersionCapabilityConsole,
+		ClusterVersionCapabilityInsights,
+		ClusterVersionCapabilityMarketplace,
+		ClusterVersionCapabilityStorage,
+		ClusterVersionCapabilityOpenShiftSamples,
+		ClusterVersionCapabilityCSISnapshot,
+		ClusterVersionCapabilityNodeTuning,
+		ClusterVersionCapabilityMachineAPI,
+		ClusterVersionCapabilityBuild,
+		ClusterVersionCapabilityDeploymentConfig,
+		ClusterVersionCapabilityImageRegistry,
+		ClusterVersionCapabilityOperatorLifecycleManager,
+	},
 	ClusterVersionCapabilitySetCurrent: {
 		ClusterVersionCapabilityBaremetal,
 		ClusterVersionCapabilityConsole,
@@ -448,6 +479,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityBuild,
 		ClusterVersionCapabilityDeploymentConfig,
 		ClusterVersionCapabilityImageRegistry,
+		ClusterVersionCapabilityOperatorLifecycleManager,
 	},
 }
 

--- a/vendor/github.com/openshift/api/config/v1/types_feature.go
+++ b/vendor/github.com/openshift/api/config/v1/types_feature.go
@@ -163,16 +163,13 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		Disabled: []FeatureGateDescription{},
 	},
 	TechPreviewNoUpgrade: newDefaultFeatures().
-		without(validatingAdmissionPolicy).
-		with(externalCloudProvider).
-		with(externalCloudProviderGCP).
+		with(validatingAdmissionPolicy).
 		with(csiDriverSharedResource).
 		with(nodeSwap).
 		with(machineAPIProviderOpenStack).
 		with(insightsConfigAPI).
 		with(retroactiveDefaultStorageClass).
 		with(dynamicResourceAllocation).
-		with(admissionWebhookMatchConditions).
 		with(gateGatewayAPI).
 		with(maxUnavailableStatefulSet).
 		without(eventedPleg).
@@ -183,6 +180,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(automatedEtcdBackup).
 		without(machineAPIOperatorDisableMachineHealthCheckController).
 		with(adminNetworkPolicy).
+		with(dnsNameResolver).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),
@@ -194,7 +192,9 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		alibabaPlatform, // This is a bug, it should be TechPreviewNoUpgrade. This must be downgraded before 4.14 is shipped.
 		azureWorkloadIdentity,
 		cloudDualStackNodeIPs,
+		externalCloudProvider,
 		externalCloudProviderAzure,
+		externalCloudProviderGCP,
 		externalCloudProviderExternal,
 		privateHostedZoneAWS,
 		buildCSIVolumes,

--- a/vendor/github.com/openshift/api/config/v1/types_image.go
+++ b/vendor/github.com/openshift/api/config/v1/types_image.go
@@ -64,12 +64,10 @@ type ImageSpec struct {
 }
 
 type ImageStatus struct {
-
 	// internalRegistryHostname sets the hostname for the default internal image
 	// registry. The value must be in "hostname[:port]" format.
 	// This value is set by the image registry operator which controls the internal registry
-	// hostname. For backward compatibility, users can still use OPENSHIFT_DEFAULT_REGISTRY
-	// environment variable but this setting overrides the environment variable.
+	// hostname.
 	// +optional
 	InternalRegistryHostname string `json:"internalRegistryHostname,omitempty"`
 

--- a/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
+++ b/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
@@ -622,7 +622,7 @@ type GCPResourceLabel struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern=`^[a-z][0-9a-z_-]+$`
+	// +kubebuilder:validation:Pattern=`^[a-z][0-9a-z_-]{0,62}$`
 	Key string `json:"key"`
 
 	// value is the value part of the label. A label value can have a maximum of 63 characters and cannot be empty.
@@ -630,7 +630,7 @@ type GCPResourceLabel struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern=`^[0-9a-z_-]+$`
+	// +kubebuilder:validation:Pattern=`^[0-9a-z_-]{1,63}$`
 	Value string `json:"value"`
 }
 

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
@@ -903,7 +903,7 @@ func (ImageSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ImageStatus = map[string]string{
-	"internalRegistryHostname":  "internalRegistryHostname sets the hostname for the default internal image registry. The value must be in \"hostname[:port]\" format. This value is set by the image registry operator which controls the internal registry hostname. For backward compatibility, users can still use OPENSHIFT_DEFAULT_REGISTRY environment variable but this setting overrides the environment variable.",
+	"internalRegistryHostname":  "internalRegistryHostname sets the hostname for the default internal image registry. The value must be in \"hostname[:port]\" format. This value is set by the image registry operator which controls the internal registry hostname.",
 	"externalRegistryHostnames": "externalRegistryHostnames provides the hostnames for the default external image registry. The external hostname should be set only when the image registry is exposed externally. The first value is used in 'publicDockerImageRepository' field in ImageStreams. The value must be in \"hostname[:port]\" format.",
 }
 

--- a/vendor/github.com/openshift/cluster-api-provider-agent/api/v1alpha1/agentcluster_types.go
+++ b/vendor/github.com/openshift/cluster-api-provider-agent/api/v1alpha1/agentcluster_types.go
@@ -78,7 +78,6 @@ type AgentClusterStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:deprecatedversion:warning="v1alpha1 is a deprecated version for AgentCluster"
 
 // AgentCluster is the Schema for the agentclusters API
 type AgentCluster struct {

--- a/vendor/github.com/openshift/cluster-api-provider-agent/api/v1alpha1/agentmachine_types.go
+++ b/vendor/github.com/openshift/cluster-api-provider-agent/api/v1alpha1/agentmachine_types.go
@@ -101,7 +101,6 @@ type AgentMachineStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:deprecatedversion:warning="v1alpha1 is a deprecated version for AgentMachine"
 
 // AgentMachine is the Schema for the agentmachines API
 type AgentMachine struct {

--- a/vendor/github.com/openshift/cluster-api-provider-agent/api/v1alpha1/agentmachinetemplate_types.go
+++ b/vendor/github.com/openshift/cluster-api-provider-agent/api/v1alpha1/agentmachinetemplate_types.go
@@ -27,7 +27,6 @@ type AgentMachineTemplateSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=agentmachinetemplates,scope=Namespaced,categories=cluster-api,shortName=agentmt
-//+kubebuilder:deprecatedversion:warning="v1alpha1 is a deprecated version for AgentMachineTemplate"
 
 // AgentMachineTemplate is the Schema for the agentmachinetemplates API
 type AgentMachineTemplate struct {

--- a/vendor/github.com/openshift/cluster-api-provider-agent/api/v1alpha1/conversion.go
+++ b/vendor/github.com/openshift/cluster-api-provider-agent/api/v1alpha1/conversion.go
@@ -1,6 +1,0 @@
-package v1alpha1
-
-// Declare the types in this version as the Hub
-func (*AgentCluster) Hub()         {}
-func (*AgentMachine) Hub()         {}
-func (*AgentMachineTemplate) Hub() {}

--- a/vendor/github.com/openshift/cluster-api-provider-agent/api/v1alpha1/groupversion_info.go
+++ b/vendor/github.com/openshift/cluster-api-provider-agent/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the capi-provider v1alpha1 API group
-// +kubebuilder:object:generate=true
-// +groupName=capi-provider.agent-install.openshift.io
+//+kubebuilder:object:generate=true
+//+groupName=capi-provider.agent-install.openshift.io
 package v1alpha1
 
 import (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,7 +209,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift/api v0.0.0-20230915112357-693d4b64813c
+# github.com/openshift/api v0.0.0-20231020115248-f404f2bc3524
 ## explicit; go 1.20
 github.com/openshift/api/config/v1
 # github.com/openshift/assisted-service/api v0.0.0-20220811161334-09c4cb098e96 => github.com/openshift/assisted-service/api v0.0.0-20220811161334-09c4cb098e96


### PR DESCRIPTION
Missed updating the vendor directory in https://github.com/openshift/cluster-api-provider-agent/pull/89
/cc @filanov 