### PR TITLE
ACM-8593: Update ignition token on refresh

### DIFF
--- a/controllers/agentmachine_controller.go
+++ b/controllers/agentmachine_controller.go
@@ -500,7 +500,7 @@ func (r *AgentMachineReconciler) processBootstrapDataSecret(ctx context.Context,
 	if apierrors.IsAlreadyExists(err) {
 		log.Infof("ignitionTokenSecret %s already exists, updating secret content",
 			fmt.Sprintf("agent-%s", *machine.Spec.Bootstrap.DataSecretName))
-		err = ensureSecretLabel(ctx, r.Client, ignitionTokenSecret)
+		err = r.Client.Update(ctx, ignitionTokenSecret)
 	}
 	if err != nil {
 		log.WithError(err).Error("Failed to create ignitionTokenSecret")


### PR DESCRIPTION
The call to Update was replaced by ensureSecretLabel in commit 83908f2e80bc. This introduces a bug because ensureSecretLabel calls Update only if a label doesn't already exist, whereas we need to call it every time.