### PR TITLE
OCPBUGS-24922: Retrieve Agent object directly

### DIFF
--- a/controllers/agentmachine_controller.go
+++ b/controllers/agentmachine_controller.go
@@ -65,6 +65,7 @@ type AgentMachineReconciler struct {
 	Scheme      *runtime.Scheme
 	Log         logrus.FieldLogger
 	AgentClient client.Client
+	APIReader   client.Reader
 }
 
 //+kubebuilder:rbac:groups=capi-provider.agent-install.openshift.io,resources=agentmachines,verbs=get;list;watch;create;update;patch;delete
@@ -552,7 +553,7 @@ func (r *AgentMachineReconciler) updateStatus(ctx context.Context, log logrus.Fi
 func (r *AgentMachineReconciler) getAgent(ctx context.Context, log logrus.FieldLogger, agentMachine *capiproviderv1.AgentMachine) (*aiv1beta1.Agent, error) {
 	agent := &aiv1beta1.Agent{}
 	agentRef := types.NamespacedName{Name: agentMachine.Status.AgentRef.Name, Namespace: agentMachine.Status.AgentRef.Namespace}
-	if err := r.AgentClient.Get(ctx, agentRef, agent); err != nil {
+	if err := r.APIReader.Get(ctx, agentRef, agent); err != nil {
 		log.WithError(err).Errorf("Failed to get agent %s", agentRef)
 		return nil, err
 	}

--- a/controllers/agentmachine_controller_test.go
+++ b/controllers/agentmachine_controller_test.go
@@ -218,6 +218,7 @@ var _ = Describe("agentmachine reconcile", func() {
 			Scheme:      scheme.Scheme,
 			Log:         logrus.New(),
 			AgentClient: c,
+			APIReader:   c,
 		}
 	})
 

--- a/main.go
+++ b/main.go
@@ -136,6 +136,7 @@ func main() {
 		Scheme:      mgr.GetScheme(),
 		Log:         logger,
 		AgentClient: agentClient,
+		APIReader:   mgr.GetAPIReader(),
 	}).SetupWithManager(mgr, agentsNamespace); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AgentMachine")
 		os.Exit(1)


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-24922
To prevent the AgentMachine from retrieving a cached Agent (resulting in stale data).

/cc @avishayt 