### PR TITLE
OCPBUGS-27251: Requeue AgentMachine if failed to find Agent

### DIFF
--- a/controllers/agentmachine_controller.go
+++ b/controllers/agentmachine_controller.go
@@ -146,7 +146,7 @@ func (r *AgentMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		var foundAgent *aiv1beta1.Agent
 		foundAgent, err = r.findAgent(ctx, log, agentMachine, agentCluster.Status.ClusterDeploymentRef, machineConfigPool, ignitionTokenSecretRef)
 		if foundAgent == nil || err != nil {
-			return ctrl.Result{}, r.updateStatus(ctx, log, agentMachine, err)
+			return ctrl.Result{Requeue: true}, r.updateStatus(ctx, log, agentMachine, err)
 		}
 
 		err = r.updateAgentMachineWithFoundAgent(ctx, log, agentMachine, foundAgent)

--- a/controllers/agentmachine_controller_test.go
+++ b/controllers/agentmachine_controller_test.go
@@ -259,7 +259,7 @@ var _ = Describe("agentmachine reconcile", func() {
 
 		result, err := amr.Reconcile(ctx, newAgentMachineRequest(agentMachine))
 		Expect(err).To(BeNil())
-		Expect(result).To(Equal(ctrl.Result{}))
+		Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 
 		Expect(c.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "agentMachine-1"}, agentMachine)).To(Succeed())
 		Expect(controllerutil.ContainsFinalizer(agentMachine, AgentMachineFinalizerName)).To(BeTrue())
@@ -281,7 +281,7 @@ var _ = Describe("agentmachine reconcile", func() {
 
 		result, err := amr.Reconcile(ctx, newAgentMachineRequest(agentMachine))
 		Expect(err).To(BeNil())
-		Expect(result).To(Equal(ctrl.Result{}))
+		Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 
 		Expect(c.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "agentMachine-0"}, agentMachine)).To(BeNil())
 		Expect(conditions.Get(agentMachine, capiproviderv1.AgentReservedCondition).Status).To(BeEquivalentTo("False"))


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-27251
It's possible that there are no valid Agents when an AgentMachine is created. The Agent will become valid later, but that doesn't cause the reconcile loop to pick it up, so the AgentMachine will never end up getting an Agent without manual intervention.

This at least allows the AgentMachine to be reconciled again in the event that an existing agent does become valid.

/cc @avishayt 