### PR TITLE
NO-ISSUE: Add cloud team to the OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,4 +6,9 @@ approvers:
 - osherdp
 - carbonin
 - CrystalChun
-- filanov
+- gamli75
+- eliorerz
+- rccrdpccl
+- adriengentil
+- danmanor
+- eifrach


### PR DESCRIPTION
Add cloud team in order to ease maintenance operations on this repo like
ocm branch cut-off.
