### PR TITLE
MGMT-18313: Replace golang base image as it is based on Centos Linux 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/openshift/release:golang-1.20 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as builder
+
+USER 0
 
 WORKDIR /workspace
 COPY . .
 # Build
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-FROM registry.ci.openshift.org/ocp/4.14:base
+FROM quay-proxy.ci.openshift.org/openshift/ci:ocp_4.16_base-rhel9
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-api-provider-agent
 
-go 1.18
+go 1.20
 
 // Versions to be held for v1beta1
 // sigs.k8s.io/controller-runtime on v0.11.x


### PR DESCRIPTION
This PR

- Bumps golang version to 1.20 (as some dependencies require)
- Replaces golang base image to UBI (as CI golang base image is based on Centos Linux 7)