### PR TITLE
OCPBUGS-32592: Ensure Agent isn't unbound if paused

### DIFF
--- a/controllers/agentmachine_controller.go
+++ b/controllers/agentmachine_controller.go
@@ -208,7 +208,11 @@ func (r *AgentMachineReconciler) handleDeletionHook(ctx context.Context, log log
 	}
 
 	// Skip agent unbind if AgentMachine is paused
-	if paused := agentMachine.Annotations[clusterv1.PausedAnnotation]; !agentMachine.ObjectMeta.DeletionTimestamp.IsZero() && paused == "true" {
+	if paused := agentMachine.Annotations[clusterv1.PausedAnnotation]; paused == "true" {
+		if agentMachine.ObjectMeta.DeletionTimestamp.IsZero() {
+			log.Info("AgentMachine paused, but not being deleted yet")
+			return nil, nil
+		}
 		log.Info("Skipping unbinding agent since agent machine is paused. Removing machine delete hook annotation")
 		if err := r.removeHookAndFinalizer(ctx, machine, agentMachine); err != nil {
 			log.Error(err)


### PR DESCRIPTION
Originally, the condition to not unbind the Agent
was based on if the AgentMachine is paused AND if the AgentMachine had a deletionTimestamp. This caused
the Agent to be unbound when the deletionTimestamp didn't exist yet on the AgentMachine, and is flawed logic.
This change updates the condition to make sure we
don't continue to unbind the Agent if the AgentMachine is at all paused.

/cc @carbonin 