### PR TITLE
[ACM 2.12] MGMT-19137: Add schemes when remote client is created

### DIFF
--- a/controllers/remote_client.go
+++ b/controllers/remote_client.go
@@ -37,6 +37,7 @@ type remoteClient struct {
 }
 
 func NewRemoteClient(localClient client.Client, scheme *runtime.Scheme) RemoteClientHandler {
+	scheme = GetKubeClientSchemes(scheme)
 	return &remoteClient{localClient: localClient, scheme: scheme}
 }
 
@@ -69,8 +70,7 @@ func (r *remoteClient) GetRemoteClient(ctx context.Context, secretNamespace stri
 		return nil, errors.Wrapf(err, "failed to get restconfig for remote kube client")
 	}
 
-	schemes := GetKubeClientSchemes(r.scheme)
-	targetClient, err := client.New(restConfig, client.Options{Scheme: schemes})
+	targetClient, err := client.New(restConfig, client.Options{Scheme: r.scheme})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get remote kube client")
 	}


### PR DESCRIPTION
This is a backport of MGMT-18689 and #149 to ACM 2.12.

Currently we add schemes to the remote client with every call to the `GetRemoteClient` method. But this is called during reconciliation, when there may be other things trying to read those schemes. That can potentially cause a concurrent map read and map write. To reduce the chances of that happening this patch changes the code so that the schemes will be added only when the remote client is created, which happens only once.

Related: https://issues.redhat.com/browse/MGMT-19137
Related: https://issues.redhat.com/browse/MGMT-18689