### PR TITLE
MGMT-19819: Add the commit reference from which the image is built to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,13 @@ COPY . .
 # Build
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
+# Extract the commit reference from which the image is built
+RUN git rev-parse --short HEAD > /commit-reference.txt
+
 FROM quay-proxy.ci.openshift.org/openshift/ci:ocp_4.16_base-rhel9
+
+# Copy the commit reference from the builder
+COPY --from=builder /commit-reference.txt /commit-reference.txt
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
Currently, in most of assisted installer components CI images we don't have a way to tell from which commit reference the image was built. Since We use an image stream for each component, and we import these streams from one CI component configuration to another, we might end up with images to are not up-to-date. In this case, we would like to have the ability to check if this is actually the case.