### PR TITLE
ACM-21348: Update builder image in Dockerfile.rhtap

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.21 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 as builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
Previously it was on RHEL 8 which causes this failure when scanned:
```
could not find dependent openssl version within container image: libcrypto.so.1.1
```

/cc @gamli75 @gparvin 