### PR TITLE
NO-ISSUE: Add missing build params to Konflux files

### DIFF
--- a/.tekton/cluster-api-provider-agent-mce-210-pull-request.yaml
+++ b/.tekton/cluster-api-provider-agent-mce-210-pull-request.yaml
@@ -34,6 +34,12 @@ spec:
     value: Dockerfile.rhtap
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/cluster-api-provider-agent-mce-210-push.yaml
+++ b/.tekton/cluster-api-provider-agent-mce-210-push.yaml
@@ -26,11 +26,20 @@ spec:
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-agent-mce-210:{{revision}}
   - name: build-platforms
     value:
-    - linux/x86_64
+      - linux/x86_64
+      - linux/ppc64le
+      - linux/s390x
+      - linux/arm64
   - name: dockerfile
     value: Dockerfile.rhtap
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
Konflux builds kept failing the verify job because of the missing parameters.

E.g. https://github.com/openshift/cluster-api-provider-agent/runs/46959159335

Slack thread: https://redhat-internal.slack.com/archives/C06TJJ3E0MU/p1753985073779699

/cc @gamli75 