### PR TITLE
NO-ISSUE: Fix MCE 2.10 Konflux violations

### DIFF
--- a/.tekton/cluster-api-provider-agent-mce-210-pull-request.yaml
+++ b/.tekton/cluster-api-provider-agent-mce-210-pull-request.yaml
@@ -607,7 +607,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:7d1c087d7d33dd97effb3b4c9f3788e4c3138da2032040d69da6929e9a3aaceb
+          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:e127e0e0a5aab1364b560436594fe7ed67abcd5f8d6dd3ef14ac1f35cf81078c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cluster-api-provider-agent-mce-210-push.yaml
+++ b/.tekton/cluster-api-provider-agent-mce-210-push.yaml
@@ -607,7 +607,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:7d1c087d7d33dd97effb3b4c9f3788e4c3138da2032040d69da6929e9a3aaceb
+          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:e127e0e0a5aab1364b560436594fe7ed67abcd5f8d6dd3ef14ac1f35cf81078c
         - name: kind
           value: task
         resolver: bundles

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -22,6 +22,3 @@ COPY --from=builder /workspace/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]
-
-ARG QUAY_TAG_EXPIRATION
-LABEL "quay.expires-after"=${QUAY_TAG_EXPIRATION}


### PR DESCRIPTION
Updates RPMS signature scan image to latest, trusted image. Removes quay.expires-after tag from dockerfile.

Slack thread: https://redhat-internal.slack.com/archives/C06TJJ3E0MU/p1755621821254569?thread_ts=1755543725.144619&cid=C06TJJ3E0MU