### PR TITLE
NO-ISSUE: Add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "postUpdateOptions": [
+      "gomodTidy", "gomodVendor"
+    ]
+}


### PR DESCRIPTION
Dependency upgrade PRs created by Konflux/mintmaker do not currently run `go mod vendor` and that
causes build errors. This adds a renovate
custom config to always run go mod vendor for
those PRs.