### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cluster-api-provider-agent-mce-29

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -8,7 +8,8 @@ RUN CGO_ENABLED=1 go build -a -o manager main.go
 
 FROM registry.redhat.io/rhel9-2-els/rhel:9.2
 LABEL \
-    name="cluster-api-provider-agent" \
+    name="multicluster-engine/cluster-api-provider-agent-rhel9" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
     com.redhat.component="cluster-api-provider-agent" \
     description="Kubernetes-native declarative infrastructure for agent-based installation. \
     cluster-api-provider-agent serves as infrastructure provider for Kubernetes cluster-api." \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
