### PR TITLE
NO-ISSUE: Update renovate to only update dependencies for master branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "timezone": "America/New_York",
     "commitMessagePrefix": "NO-ISSUE: ",
     "prHourlyLimit": 0,
-    "prConcurrentLimit": 0,
+    "prConcurrentLimit": 20,
     "vulnerabilityAlerts": {
       "enabled": true
     },
@@ -13,21 +13,20 @@
       "pinDigests": true
     },
     "enabledManagers": [
-        "tekton",
         "gomod",
         "dockerfile"
     ],
-    "gomod": {
-      "packageRules": [
-        {
-          "matchDepTypes": ["indirect"],
-          "enabled": false
-        }
-      ]
-    },
-    "tekton": {
-      "fileMatch": ["^.tekton/*"]
-    },
+    "packageRules": [
+      {
+        "matchManagers": "gomod",
+        "matchDepTypes": ["indirect"],
+        "enabled": false
+      },
+      {
+        "matchManagers": "gomod",
+        "matchBaseBranches": "master"
+      }
+    ],
     "postUpdateOptions": [
       "gomodTidy", "gomodVendor"
     ]


### PR DESCRIPTION
Since we've added tekton files to every `release-ocm-xxx` branch, renovate will open PRs to update dependencies on those branches too. This is unnecessary as they are maintained release branches for ACM, but they do not need dependency upgrades.