### PR TITLE
NO-ISSUE: Disable updating konflux dependencies on prior ACM branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,13 +18,19 @@
     ],
     "packageRules": [
       {
-        "matchManagers": "gomod",
+        "matchManagers": ["gomod"],
         "matchDepTypes": ["indirect"],
         "enabled": false
       },
       {
-        "matchManagers": "gomod",
-        "matchBaseBranches": "master"
+        "matchManagers": ["gomod"],
+        "matchBaseBranches": ["master"],
+        "enabled": true
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchBaseBranches": ["release-ocm-.*"],
+        "enabled": false
       }
     ],
     "postUpdateOptions": [


### PR DESCRIPTION
Prevent updating the dependencies on `release-ocm-2.X.Y` branches as these branches are needed for Z-stream konflux builds of ACM, but do not need dependency updates.