### PR TITLE
NO-ISSUE: Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,7 @@
         },
         {
           "matchBaseBranches": [
+            "release-ocm-2.11",
             "release-ocm-2.12",
             "release-ocm-2.13",
             "release-ocm-2.14",
@@ -52,6 +53,7 @@
       {
         "matchManagers": ["gomod"],
         "matchBaseBranches": [
+            "release-ocm-2.11",
             "release-ocm-2.12",
             "release-ocm-2.13",
             "release-ocm-2.14",


### PR DESCRIPTION
Include `"release-ocm-2.11"` in the ignore update dependencies