### PR TITLE
[release-ocm-2.16] NO-ISSUE: Update envtest version to release-0.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ NAMESPACE ?= cluster-api-provider-agent
 WATCH_NAMESPACE ?= ""
 AGENTS_NAMESPACE ?= ""
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.21
+ENVTEST_K8S_VERSION = 1.30
 
 # Runtime CLI to use for building and pushing images
 RUNTIME ?= docker
@@ -155,7 +155,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240315194348-5aaf1190f880)
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22)
 
 MOCKGEN = $(shell pwd)/bin/mockgen
 mockgen: ## Download mockgen locally if necessary.


### PR DESCRIPTION
The envtest version needs to be in alignment with the Go version or else running unit tests will fail


/cc @gamli75 