### PR TITLE
NO-ISSUE: Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,8 @@
             "release-ocm-2.13",
             "release-ocm-2.14",
             "release-ocm-2.15",
-            "release-ocm-2.16"
+            "release-ocm-2.16",
+            "release-ocm-2.17"
           ],
           "matchManagers": [
             "gomod"
@@ -56,6 +57,19 @@
       ]
     },
     "packageRules": [
+      {
+        "matchManagers": ["custom.regex"],
+        "matchBaseBranches": [
+          "release-ocm-2.11",
+          "release-ocm-2.12",
+          "release-ocm-2.13",
+          "release-ocm-2.14",
+          "release-ocm-2.15",
+          "release-ocm-2.16",
+          "release-ocm-2.17"
+        ],
+        "enabled": false
+      },
       {
         "matchManagers": ["gomod"],
         "matchDepTypes": ["indirect"],
@@ -74,7 +88,8 @@
             "release-ocm-2.13",
             "release-ocm-2.14",
             "release-ocm-2.15",
-            "release-ocm-2.16"
+            "release-ocm-2.16",
+            "release-ocm-2.17"
         ],
         "enabled": false
       },
@@ -86,7 +101,8 @@
         "addLabels": [
             "ubi",
             "lgtm",
-            "approved"
+            "approved",
+            "ok-to-test"
         ]
       },
       {
@@ -113,9 +129,9 @@
           "hive-api",
           "api-sync",
           "lgtm",
-          "approved"
-        ],
-        "enabled": true
+          "approved",
+          "ok-to-test"
+        ]
       }
     ],
     "postUpdateOptions": [


### PR DESCRIPTION
Only update ubi images on master and add
`ok-to-test` labels on go mod and ubi image
updates. Add release-ocm-2.17 to ignore list
for dependency updates.

/cc @shay23bra 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management rules to include additional release branches (release-ocm-2.11–2.17) and to disable automated updates for custom-regex–managed dependencies on those branches.
  * Enhanced automation labels: added "ok-to-test" alongside "approved" for runtime image updates and API synchronization rules to improve build tracking and approvals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->