### PR TITLE
ACM-33186: Revert Renovate configuration for Hive updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,12 +5,16 @@
     "prHourlyLimit": 0,
     "prConcurrentLimit": 20,
     "vulnerabilityAlerts": {
-      "enabled": true
+        "enabled": true
     },
     "dockerfile": {
-      "fileMatch": ["Dockerfile.rhtap"],
-      "ignorePaths": ["**/Dockerfile"],
-      "pinDigests": true
+        "fileMatch": [
+            "Dockerfile.rhtap"
+        ],
+        "ignorePaths": [
+            "**/Dockerfile"
+        ],
+        "pinDigests": true
     },
     "customManagers": [
         {
@@ -32,93 +36,88 @@
         "custom.regex"
     ],
     "gomod": {
-      "packageRules": [
-        {
-          "matchDepTypes": [
-            "indirect"
-          ],
-          "enabled": false
-        },
-        {
-          "matchBaseBranches": [
-            "release-ocm-2.11",
-            "release-ocm-2.12",
-            "release-ocm-2.13",
-            "release-ocm-2.14",
-            "release-ocm-2.15",
-            "release-ocm-2.16"
-          ],
-          "matchManagers": [
-            "gomod"
-          ],
-          "enabled": false
-        }
-      ]
+        "packageRules": [
+            {
+                "matchDepTypes": [
+                    "indirect"
+                ],
+                "enabled": false
+            },
+            {
+                "matchBaseBranches": [
+                    "release-ocm-2.11",
+                    "release-ocm-2.12",
+                    "release-ocm-2.13",
+                    "release-ocm-2.14",
+                    "release-ocm-2.15",
+                    "release-ocm-2.16"
+                ],
+                "matchManagers": [
+                    "gomod"
+                ],
+                "enabled": false
+            }
+        ]
     },
     "packageRules": [
-      {
-        "matchManagers": ["gomod"],
-        "matchDepTypes": ["indirect"],
-        "enabled": false
-      },
-      {
-        "matchManagers": ["gomod"],
-        "matchBaseBranches": ["master"],
-        "enabled": true
-      },
-      {
-        "matchManagers": ["gomod"],
-        "matchBaseBranches": [
-            "release-ocm-2.11",
-            "release-ocm-2.12",
-            "release-ocm-2.13",
-            "release-ocm-2.14",
-            "release-ocm-2.15",
-            "release-ocm-2.16"
-        ],
-        "enabled": false
-      },
-      {
-        "matchPackageNames": [
-            "registry.access.redhat.com/ubi9/ubi-minimal"
-        ],
-        "groupName": "UBI Runtime Images",
-        "addLabels": [
-            "ubi",
-            "lgtm",
-            "approved"
-        ]
-      },
-      {
-        "matchUpdateTypes": [
-            "major"
-        ],
-        "matchDatasources": [
-            "docker"
-        ],
-        "matchPackageNames": [
-            "registry.access.redhat.com/ubi9/ubi-minimal"
-        ],
-        "enabled": false
-      },
-      {
-        "matchManagers": [
-          "gomod"
-        ],
-        "matchPackageNames": [
-          "github.com/openshift/hive/apis"
-        ],
-        "groupName": "Hive API Synchronization",
-        "addLabels": [
-          "hive-api",
-          "api-sync",
-          "lgtm",
-          "approved"
-        ],
-        "enabled": true
-      }
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchDepTypes": [
+                "indirect"
+            ],
+            "enabled": false
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchBaseBranches": [
+                "master"
+            ],
+            "enabled": true
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchBaseBranches": [
+                "release-ocm-2.11",
+                "release-ocm-2.12",
+                "release-ocm-2.13",
+                "release-ocm-2.14",
+                "release-ocm-2.15",
+                "release-ocm-2.16"
+            ],
+            "enabled": false
+        },
+        {
+            "matchPackageNames": [
+                "registry.access.redhat.com/ubi9/ubi-minimal"
+            ],
+            "groupName": "UBI Runtime Images",
+            "addLabels": [
+                "ubi",
+                "lgtm",
+                "approved"
+            ]
+        },
+        {
+            "matchUpdateTypes": [
+                "major"
+            ],
+            "matchDatasources": [
+                "docker"
+            ],
+            "matchPackageNames": [
+                "registry.access.redhat.com/ubi9/ubi-minimal"
+            ],
+            "enabled": false
+        }
     ],
     "postUpdateOptions": [
-      "gomodTidy", "gomodVendor"
+        "gomodTidy",
+        "gomodVendor"
     ]
 }


### PR DESCRIPTION
Revert the Renovate/MintMaker configuration that enables hive/apis digest tracking.
MintMaker generates bare commit hashes instead of proper Go pseudo-versions,
which breaks go.mod.

Reverts changes from [ACM-29247](https://redhat.atlassian.net/browse/ACM-29247) / [ACM-29261](https://redhat.atlassian.net/browse/ACM-29261) / ACM-29244.