### PR TITLE
NO-ISSUE: Update github.com/openshift/hive/apis digest to 6c66e20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/gomega v1.38.2
 	github.com/openshift/cluster-api-provider-agent/api v0.0.0-20251202202927-3ad4558809a2
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
-	github.com/openshift/hive/apis v0.0.0-20260422161834-b10cc0dc2b46
+	github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/thoas/go-funk v0.9.3

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,8 @@ github.com/openshift/assisted-service/models v0.0.0-20260423203345-4a20feaf0742 
 github.com/openshift/assisted-service/models v0.0.0-20260423203345-4a20feaf0742/go.mod h1:AIlSmaRbWvECCyZo+nuzkRijy7szsTxq+MrU9lmQRwo=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 h1:cHyxR+Y8rAMT6m1jQCaYGRwikqahI0OjjUDhFNf3ySQ=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
-github.com/openshift/hive/apis v0.0.0-20260422161834-b10cc0dc2b46 h1:ES9Lp++WUHu5y9n6DneYv+yPdepbSEtVlePF35pBQ4c=
-github.com/openshift/hive/apis v0.0.0-20260422161834-b10cc0dc2b46/go.mod h1:98U/kA+A9nenhu0mCqaxaKyYJ+C/YEZoAUkPYDT/m+c=
+github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422 h1:R8iA8JQ4k+2dNgseiFoLe3UkokexpUQTNHHb05UIuR4=
+github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422/go.mod h1:98U/kA+A9nenhu0mCqaxaKyYJ+C/YEZoAUkPYDT/m+c=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -262,7 +262,7 @@ github.com/openshift/cluster-api-provider-agent/api/v1beta1
 # github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
-# github.com/openshift/hive/apis v0.0.0-20260422161834-b10cc0dc2b46
+# github.com/openshift/hive/apis v0.0.0-20260424180847-6c66e2052422
 ## explicit; go 1.24.0
 github.com/openshift/hive/apis/hive/v1
 github.com/openshift/hive/apis/hive/v1/agent


### PR DESCRIPTION
Update github.com/openshift/hive/apis with proper Go pseudo-version.

See [ACM-29247](https://redhat.atlassian.net/browse/ACM-29247) / [ACM-29261](https://redhat.atlassian.net/browse/ACM-29261) / ACM-29244.