### PR TITLE
Revert "ACM-31614: Add Konflux files for release MCE 5.0 (#870)"

### DIFF
--- a/.tekton/cluster-api-provider-agent-mce-217-pull-request.yaml
+++ b/.tekton/cluster-api-provider-agent-mce-217-pull-request.yaml
@@ -4,17 +4,18 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/cluster-api-provider-agent?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "master"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-50
-    appstudio.openshift.io/component: cluster-api-provider-agent-mce-50
+    appstudio.openshift.io/application: release-mce-217
+    appstudio.openshift.io/component: cluster-api-provider-agent-mce-217
     pipelines.appstudio.openshift.io/type: build
-  name: cluster-api-provider-agent-mce-50-on-push
+  name: cluster-api-provider-agent-mce-217-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -23,13 +24,12 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-agent-mce-50:{{revision}}
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-agent-mce-217:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/ppc64le
-    - linux/s390x
-    - linux/arm64
   - name: dockerfile
     value: Dockerfile.rhtap
   - name: path-context
@@ -50,7 +50,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common-base.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cluster-api-provider-agent-mce-50
+    serviceAccountName: build-pipeline-cluster-api-provider-agent-mce-217
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cluster-api-provider-agent-mce-217-push.yaml
+++ b/.tekton/cluster-api-provider-agent-mce-217-push.yaml
@@ -4,18 +4,17 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/cluster-api-provider-agent?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "master"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-50
-    appstudio.openshift.io/component: cluster-api-provider-agent-mce-50
+    appstudio.openshift.io/application: release-mce-217
+    appstudio.openshift.io/component: cluster-api-provider-agent-mce-217
     pipelines.appstudio.openshift.io/type: build
-  name: cluster-api-provider-agent-mce-50-on-pull-request
+  name: cluster-api-provider-agent-mce-217-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -24,12 +23,13 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-agent-mce-50:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-agent-mce-217:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
     value: Dockerfile.rhtap
   - name: path-context
@@ -50,7 +50,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common-base.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cluster-api-provider-agent-mce-50
+    serviceAccountName: build-pipeline-cluster-api-provider-agent-mce-217
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
This reverts commit 40c1c8f026cbfb2f3f376a787407ceab51d01a7b.
The tekton files were accidentally fast-forwarded from master, this corrects the tekton files back to release-ocm-2.17.

/cc @gamli75 