### PR TITLE
MGMT-24456: upgrade to golang 1.26

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 USER 0
 

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 as builder
 
 WORKDIR /workspace
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ mockgen: ## Download mockgen locally if necessary.
 
 GOLINT = $(shell pwd)/bin/golangci-lint
 golint: ## Download golangci-lint locally if necessary.
-	$(call go-get-tool,$(GOLINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.2)
+	$(call go-get-tool,$(GOLINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/openshift/cluster-api-provider-agent
 
-go 1.25.7
+go 1.26.0
+
+toolchain go1.26.2
 
 // Versions to be held for v1beta1
 // sigs.k8s.io/controller-runtime on v0.11.x


### PR DESCRIPTION
## Summary
- Upgrade Go version from 1.25 to 1.26 in go.mod and Dockerfiles
- Update toolchain to go1.26.2
- Bump golangci-lint from v2.6.2 to v2.11.4

https://redhat.atlassian.net/browse/MGMT-24456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go runtime from 1.25.7 to 1.26.0 and pinned the Go toolchain for builds
  * Updated development tooling (golangci-lint) to v2.11.4
  * Updated container base images and CI/CD build configuration for OpenShift 5.0 compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->