### PR TITLE
MGMT-24693: Bracket IPv6 ignition endpoint URLs when creating AgentClusterInstall

### DIFF
--- a/controllers/agentcluster_controller.go
+++ b/controllers/agentcluster_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-openapi/swag"
@@ -422,18 +421,17 @@ func (r *AgentClusterReconciler) createAgentClusterInstall(ctx context.Context, 
 
 	// IgnitionEndpoint can only be set at AgentClusterInstall create time
 	if agentCluster.Spec.IgnitionEndpoint != nil {
-		url := agentCluster.Spec.IgnitionEndpoint.Url
-		agentClusterInstall.Spec.IgnitionEndpoint = &hiveext.IgnitionEndpoint{
-			// Currently assume something like https://1.2.3.4:555/ignition, otherwise this will fail
-			// TODO: Replace with something more robust
-			Url: url[0:strings.LastIndex(url, "/")],
-		}
-		if agentCluster.Spec.IgnitionEndpoint.CaCertificateReference != nil {
-			agentClusterInstall.Spec.IgnitionEndpoint.CaCertificateReference = &hiveext.CaCertificateReference{
-				Namespace: agentCluster.Spec.IgnitionEndpoint.CaCertificateReference.Namespace,
-				Name:      agentCluster.Spec.IgnitionEndpoint.CaCertificateReference.Name,
+		if ignitionURL := ignitionEndpointURLForACI(agentCluster.Spec.IgnitionEndpoint.Url); ignitionURL != "" {
+			agentClusterInstall.Spec.IgnitionEndpoint = &hiveext.IgnitionEndpoint{
+				Url: ignitionURL,
 			}
-			r.ensureSecretLabel(ctx, agentCluster.Spec.IgnitionEndpoint.CaCertificateReference.Name, agentCluster.Spec.IgnitionEndpoint.CaCertificateReference.Namespace)
+			if agentCluster.Spec.IgnitionEndpoint.CaCertificateReference != nil {
+				agentClusterInstall.Spec.IgnitionEndpoint.CaCertificateReference = &hiveext.CaCertificateReference{
+					Namespace: agentCluster.Spec.IgnitionEndpoint.CaCertificateReference.Namespace,
+					Name:      agentCluster.Spec.IgnitionEndpoint.CaCertificateReference.Name,
+				}
+				r.ensureSecretLabel(ctx, agentCluster.Spec.IgnitionEndpoint.CaCertificateReference.Name, agentCluster.Spec.IgnitionEndpoint.CaCertificateReference.Namespace)
+			}
 		}
 	}
 

--- a/controllers/ignition_endpoint.go
+++ b/controllers/ignition_endpoint.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"net"
+	"net/url"
+	"strings"
+)
+
+// normalizeHTTPURL rewrites HTTP(S) URLs that contain an unbracketed IPv6 literal host
+// so they can be parsed by net/url (Go 1.26+).
+func normalizeHTTPURL(rawURL string) string {
+	if rawURL == "" {
+		return rawURL
+	}
+
+	// Already a valid URL; no rewriting needed.
+	if _, err := url.Parse(rawURL); err == nil {
+		return rawURL
+	}
+
+	const schemeSep = "://"
+	schemeIdx := strings.Index(rawURL, schemeSep)
+	if schemeIdx < 0 {
+		return rawURL
+	}
+	scheme := rawURL[:schemeIdx+len(schemeSep)]
+	remainder := rawURL[schemeIdx+len(schemeSep):]
+
+	path := ""
+	if slash := strings.Index(remainder, "/"); slash >= 0 {
+		path = remainder[slash:]
+		remainder = remainder[:slash]
+	}
+
+	// Host is already RFC 3986 bracket form; leave unchanged.
+	if strings.HasPrefix(remainder, "[") {
+		return rawURL
+	}
+
+	// Split host from port on the last colon (IPv6 literals contain multiple colons).
+	lastColon := strings.LastIndex(remainder, ":")
+	if lastColon < 0 {
+		return rawURL
+	}
+
+	host := remainder[:lastColon]
+	port := remainder[lastColon+1:]
+	// Only rewrite when host is an IPv6 literal and a port is present.
+	if port == "" || net.ParseIP(host) == nil || !strings.Contains(host, ":") {
+		return rawURL
+	}
+
+	return scheme + net.JoinHostPort(host, port) + path
+}
+
+// ignitionEndpointURLForACI normalizes the ignition endpoint URL and strips a trailing path
+// segment (for example /ignition) before persisting it on AgentClusterInstall.
+func ignitionEndpointURLForACI(raw string) string {
+	normalized := normalizeHTTPURL(raw)
+
+	parsed, err := url.Parse(normalized)
+	if err != nil || parsed.Scheme == "" {
+		return normalized
+	}
+
+	parsed.Path = ""
+	parsed.RawPath = ""
+	return parsed.String()
+}

--- a/controllers/ignition_endpoint_test.go
+++ b/controllers/ignition_endpoint_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ignition endpoint URL helpers", func() {
+	It("normalizes unbracketed IPv6 URLs", func() {
+		Expect(normalizeHTTPURL("https://fd2e:6f44:5dd8:c956::14:31187")).
+			To(Equal("https://[fd2e:6f44:5dd8:c956::14]:31187"))
+		Expect(normalizeHTTPURL("https://fd2e:6f44:5dd8:c956::14:31187/ignition")).
+			To(Equal("https://[fd2e:6f44:5dd8:c956::14]:31187/ignition"))
+	})
+
+	It("leaves IPv4 and bracketed IPv6 URLs unchanged", func() {
+		Expect(normalizeHTTPURL("https://1.2.3.4:555/ignition")).To(Equal("https://1.2.3.4:555/ignition"))
+		Expect(normalizeHTTPURL("http://[1080::8:800:200c:417a]:123/config")).
+			To(Equal("http://[1080::8:800:200c:417a]:123/config"))
+	})
+
+	It("prepares ignition endpoint URLs for AgentClusterInstall", func() {
+		Expect(ignitionEndpointURLForACI("https://fd2e:6f44:5dd8:c956::14:31187/ignition")).
+			To(Equal("https://[fd2e:6f44:5dd8:c956::14]:31187"))
+		Expect(ignitionEndpointURLForACI("https://1.2.3.4:555/ignition")).
+			To(Equal("https://1.2.3.4:555"))
+		Expect(ignitionEndpointURLForACI("https://1.2.3.4:555")).
+			To(Equal("https://1.2.3.4:555"))
+		Expect(ignitionEndpointURLForACI("")).To(Equal(""))
+	})
+})


### PR DESCRIPTION

The edge CAPI disconnected test
pull-ci-openshift-assisted-service-master-edge-e2e-ai-operator-disconnected-capi started failing after openshift/assisted-service PR #10396 moved the stack to Go 1.26. Hypershift sets AgentCluster.spec.ignitionEndpoint.url by concatenating https://, an unbracketed IPv6 host:port from HostedCluster status, and /ignition — for example:

  https://fd2e:6f44:5dd8:c956::14:31187/ignition

This provider copies that value into AgentClusterInstall (stripping /ignition). assisted-service then rejects it under Go 1.26's stricter net/url.Parse:

  parse "https://fd2e:6f44:5dd8:c956::14:31187": invalid port
  ":6f44:5dd8:c956::14:31187" after host

leading to ACI SpecSynced InputError, ignition-downloadable pending, and a timeout with zero worker nodes on the spoke cluster. The test last passed on Go 1.25 (PR #10319); first failures appeared on PR #10396 presubmits while still on OCP 4.22.

Add ignitionEndpointURLForACI to normalize unbracketed IPv6 hosts with net.JoinHostPort and to strip a trailing path segment safely. This replaces url[0:strings.LastIndex(url, "/")], which also mishandled URLs without a path when LastIndex returned -1.

Hypershift should still be fixed at the source; this normalizes at the ACI boundary. A companion change in assisted-service applies the same normalization in ValidateHTTPFormat and parseIgnitionEndpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ignition endpoint URL handling, including normalization of unbracketed IPv6 host/port formats and correct preservation of any existing path during processing.
  * Ensured persisted ignition endpoint values use the correct scheme+host base (avoiding malformed or incomplete URLs).

* **Tests**
  * Added unit tests covering ignition endpoint URL normalization and base URL extraction for IPv4, IPv6, and path-based inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->