### PR TITLE
OCPBUGS-97814: Fix deadlock in pre-terminate hook handling with CAPI v1beta2

### DIFF
--- a/controllers/agentmachine_controller.go
+++ b/controllers/agentmachine_controller.go
@@ -284,26 +284,35 @@ func (r *AgentMachineReconciler) handleDeletionHook(ctx context.Context, log log
 		return &ctrl.Result{}, nil
 	}
 
-	// return if the machine is not waiting on this hook
-	// In v1beta2, use the V1Beta1Condition constant for backward compatibility
-	cond := conditions.Get(machine, string(clusterv1.PreTerminateDeleteHookSucceededV1Beta1Condition))
-	if cond == nil {
-		if !agentMachine.DeletionTimestamp.IsZero() {
-			log.Warnf("Not starting agent machine removal until machine %s/%s pauses for delete hook", machine.Namespace, machine.Name)
-		}
-		return nil, nil
+	// Check if the machine has reached the pre-terminate hook phase.
+	// In CAPI v1beta2, the Machine uses a "Deleting" condition with reason "WaitingForPreTerminateHook"
+	// instead of the separate v1beta1 "PreTerminateDeleteHookSucceeded" condition.
+	machineWaitingForHook := false
+	deletingCond := conditions.Get(machine, string(clusterv1.MachineDeletingCondition))
+	if deletingCond != nil && deletingCond.Reason == clusterv1.MachineDeletingWaitingForPreTerminateHookReason {
+		machineWaitingForHook = true
 	}
 
-	// If the hook was already processed and removed ensure the finalizer is removed and return
-	if cond.Status == metav1.ConditionTrue {
-		if removeFinalizerError := r.removeFinalizer(agentMachine); removeFinalizerError != nil {
-			log.Error(removeFinalizerError)
-			return &ctrl.Result{}, removeFinalizerError
+	// Fall back to checking the v1beta1 condition for backward compatibility
+	if !machineWaitingForHook {
+		v1beta1Cond := conditions.Get(machine, string(clusterv1.PreTerminateDeleteHookSucceededV1Beta1Condition))
+		if v1beta1Cond == nil {
+			if !agentMachine.DeletionTimestamp.IsZero() {
+				log.Warnf("Not starting agent machine removal until machine %s/%s pauses for delete hook", machine.Namespace, machine.Name)
+			}
+			return nil, nil
 		}
-		return &ctrl.Result{}, nil
+		// If the hook was already processed and removed ensure the finalizer is removed and return
+		if v1beta1Cond.Status == metav1.ConditionTrue {
+			if removeFinalizerError := r.removeFinalizer(agentMachine); removeFinalizerError != nil {
+				log.Error(removeFinalizerError)
+				return &ctrl.Result{}, removeFinalizerError
+			}
+			return &ctrl.Result{}, nil
+		}
 	}
 
-	log.Infof("Machine is waiting on delete hook %s", clusterv1.PreTerminateDeleteHookSucceededV1Beta1Condition)
+	log.Infof("Machine is waiting on delete hook, proceeding with agent cleanup")
 	if agentMachine.Status.AgentRef == nil {
 		log.Info("Removing machine delete hook annotation - agent ref is nil")
 		if removeHookAndFinalizerError := r.removeHookAndFinalizer(ctx, machine, agentMachine); removeHookAndFinalizerError != nil {


### PR DESCRIPTION
## Summary

Fixes a deadlock during cluster deletion on the Agent platform caused by a CAPI v1beta1/v1beta2 condition incompatibility introduced in #1020.

- The `handleDeletionHook` function only checked for the v1beta1 `PreTerminateDeleteHookSucceeded` condition, which CAPI v1.12 (v1beta2) no longer sets
- This caused a deadlock: the CAPI Machine controller waits for the `agentmachine` pre-terminate hook annotation to be removed, while the agent provider waits for a condition that is never set
- The fix checks the v1beta2 `Deleting` condition (reason `WaitingForPreTerminateHook`) first, then falls back to the v1beta1 condition for backward compatibility

Bug: https://issues.redhat.com/browse/OCPBUGS-97814

## Root Cause

In CAPI v1beta2 (upgraded in #1020), the Machine controller signals the pre-terminate hook phase via:
- `Deleting` condition with reason `WaitingForPreTerminateHook`

Instead of the v1beta1:
- `PreTerminateDeleteHookSucceeded` condition set to `False`

The agent controller was only checking the v1beta1 condition, which was always `nil`, causing `handleDeletionHook` to return early on every reconciliation without ever starting agent cleanup or removing the hook annotation.

## Test plan

- [ ] Deploy a HyperShift cluster on the Agent platform
- [ ] Destroy the cluster using `hcp destroy cluster agent --name <cluster>`
- [ ] Verify the cluster is fully deleted without timeout
- [ ] Verify Agent machines are properly unbound and returned to the available pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent cleanup during deletion to correctly handle both newer and older cluster API deletion signals.
  * The system now recognizes when a machine is waiting on the pre-terminate hook before removing cleanup markers, helping avoid premature deletion.
  * Added clearer logging when cleanup proceeds after the appropriate hook state is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->