### PR TITLE
ACM-38238: Assisted-installer repos: Set Up Set up Renovate configuration to automatically create Hive API Synchronization PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,7 +50,9 @@
     },
     "packageRules": [
         {
-            "matchManagers": ["custom.regex"],
+            "matchManagers": [
+                "custom.regex"
+            ],
             "matchBaseBranches": [
                 "release-ocm-2.11",
                 "release-ocm-2.12",
@@ -121,6 +123,23 @@
                 "registry.access.redhat.com/ubi9/ubi-minimal"
             ],
             "enabled": false
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchPackageNames": [
+                "github.com/openshift/hive/apis"
+            ],
+            "groupName": "Hive API Synchronization",
+            "addLabels": [
+                "hive-api",
+                "api-sync",
+                "lgtm",
+                "approved",
+                "ok-to-test"
+            ],
+            "enabled": true
         }
     ],
     "postUpdateOptions": [


### PR DESCRIPTION
Set up Renovate configuration to automatically create Hive API Synchronization PRs.

Adds packageRule enabling github.com/openshift/hive/apis updates (gomod already enabled in this repo).

Re-applies changes that were reverted by ACM-33186. Renovate issue is now resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update configuration to include a new rule for Hive API synchronization.
  * Added dedicated categorization labels to make these updates easier to identify and track.
  * Reformatted an existing dependency matching configuration for readability without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->