### PR TITLE
ACM-38238: Assisted-installer repos: Set Up Set up Renovate configuration to automatically create Hive API Synchronization PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,66 +5,98 @@
     "prHourlyLimit": 0,
     "prConcurrentLimit": 20,
     "vulnerabilityAlerts": {
-      "enabled": true
+        "enabled": true
     },
     "dockerfile": {
-      "fileMatch": ["Dockerfile.rhtap"],
-      "ignorePaths": ["**/Dockerfile"],
-      "pinDigests": true
+        "fileMatch": [
+            "Dockerfile.rhtap"
+        ],
+        "ignorePaths": [
+            "**/Dockerfile"
+        ],
+        "pinDigests": true
     },
     "enabledManagers": [
         "gomod",
         "dockerfile"
     ],
     "gomod": {
-      "packageRules": [
-        {
-          "matchDepTypes": [
-            "indirect"
-          ],
-          "enabled": false
-        },
-        {
-          "matchBaseBranches": [
-            "release-ocm-2.11",
-            "release-ocm-2.12",
-            "release-ocm-2.13",
-            "release-ocm-2.14",
-            "release-ocm-2.15",
-            "release-ocm-2.16"
-          ],
-          "matchManagers": [
-            "gomod"
-          ],
-          "enabled": false
-        }
-      ]
+        "packageRules": [
+            {
+                "matchDepTypes": [
+                    "indirect"
+                ],
+                "enabled": false
+            },
+            {
+                "matchBaseBranches": [
+                    "release-ocm-2.11",
+                    "release-ocm-2.12",
+                    "release-ocm-2.13",
+                    "release-ocm-2.14",
+                    "release-ocm-2.15",
+                    "release-ocm-2.16"
+                ],
+                "matchManagers": [
+                    "gomod"
+                ],
+                "enabled": false
+            }
+        ]
     },
     "packageRules": [
-      {
-        "matchManagers": ["gomod"],
-        "matchDepTypes": ["indirect"],
-        "enabled": false
-      },
-      {
-        "matchManagers": ["gomod"],
-        "matchBaseBranches": ["master"],
-        "enabled": true
-      },
-      {
-        "matchManagers": ["gomod"],
-        "matchBaseBranches": [
-            "release-ocm-2.11",
-            "release-ocm-2.12",
-            "release-ocm-2.13",
-            "release-ocm-2.14",
-            "release-ocm-2.15",
-            "release-ocm-2.16"
-        ],
-        "enabled": false
-      }
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchDepTypes": [
+                "indirect"
+            ],
+            "enabled": false
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchBaseBranches": [
+                "master"
+            ],
+            "enabled": true
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchBaseBranches": [
+                "release-ocm-2.11",
+                "release-ocm-2.12",
+                "release-ocm-2.13",
+                "release-ocm-2.14",
+                "release-ocm-2.15",
+                "release-ocm-2.16"
+            ],
+            "enabled": false
+        },
+        {
+            "matchManagers": [
+                "gomod"
+            ],
+            "matchPackageNames": [
+                "github.com/openshift/hive/apis"
+            ],
+            "groupName": "Hive API Synchronization",
+            "addLabels": [
+                "hive-api",
+                "api-sync",
+                "lgtm",
+                "approved",
+                "ok-to-test"
+            ],
+            "enabled": true
+        }
     ],
     "postUpdateOptions": [
-      "gomodTidy", "gomodVendor"
+        "gomodTidy",
+        "gomodVendor"
     ]
 }


### PR DESCRIPTION
Set up Renovate configuration to automatically create Hive API Synchronization PRs.

Adds packageRule enabling github.com/openshift/hive/apis updates (gomod already enabled in this repo).

Re-applies changes that were reverted by ACM-33186. Renovate issue is now resolved.